### PR TITLE
Fix encumbrance validator for root actors

### DIFF
--- a/scripts/encumbrance-monitor.js
+++ b/scripts/encumbrance-monitor.js
@@ -112,6 +112,11 @@ export class DragonbaneEncumbranceMonitor {
 
     const targetFolder = this.getSetting("encumbranceMonitorFolder", "Party");
 
+    if (targetFolder === "") {
+      // Empty target folder means monitor all characters
+      return true;
+    }
+
     // Handle both folder object and folder ID cases
     let actorFolder = null;
     if (actor.folder) {
@@ -128,9 +133,9 @@ export class DragonbaneEncumbranceMonitor {
       }
     }
 
-    if (targetFolder === "") {
-      // Empty target folder means monitor all characters
-      return true;
+    // Target folder is configured but this actor is not in a folder
+    if (!actorFolder) {
+      return false;
     }
 
     return actorFolder.name === targetFolder;


### PR DESCRIPTION
Fix encumbrance validator check if target folder is configured (default), but some actors are not located in any folder.

Also, move empty targetFolder condition check earlier since we don't need actorFolder to exit early.